### PR TITLE
single compartmental cell file added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ x86_64
 /NEURON/channels/*.dat
 /NeuroML2/L5_model2.cell.png
 *.ipynb
-
+*.xml

--- a/NeuroML2/ih.channel.nml
+++ b/NeuroML2/ih.channel.nml
@@ -17,11 +17,11 @@
                 Predominantly HCN1 / HCN2
         </notes>  
         
-        <gateHHtauInf id="qq" instances="1">
+        <gateHHrates id="qq" instances="1">
             <q10Settings type="q10ExpTemp" q10Factor="2.3" experimentalTemp="23degC"/> 
             <forwardRate type="HHExpLinearRate" rate="-0.00643per_ms" scale="11.9mV" midpoint="-154.9mV"/>
             <reverseRate type="HHExpRate" rate="0.193per_ms" scale="33.1mV" midpoint="0mV"/>
-        </gateHHtauInf>
+        </gateHHrates>
     </ionChannel>
 
 </neuroml>

--- a/NeuroML2/ih.channel.nml
+++ b/NeuroML2/ih.channel.nml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2beta4.xsd" 
+         id="ih">
+
+    <notes>NeuroML file automatically generated from an NMODL file</notes>
+
+    <ionChannel id="ih" conductance="10pS" type="ionChannelHH" species="hcn">
+        
+        <notes>Deterministic model of kinetics and voltage-dependence of Ih-currents
+                in layer 5 pyramidal neuron, see Kole et al., 2006. Implemented by
+                Stefan Hallermann.
+
+                Added possibility to shift voltage activiation (vshift) and allowed access to gating variables, Armin Bahl 2009
+
+                Predominantly HCN1 / HCN2
+        </notes>  
+        
+        <gateHHtauInf id="qq" instances="1">
+            <q10Settings type="q10ExpTemp" q10Factor="2.3" experimentalTemp="23degC"/> 
+            <forwardRate type="HHExpLinearRate" rate="-0.00643per_ms" scale="11.9mV" midpoint="-154.9mV"/>
+            <reverseRate type="HHExpRate" rate="0.193per_ms" scale="33.1mV" midpoint="0mV"/>
+        </gateHHtauInf>
+    </ionChannel>
+
+</neuroml>

--- a/NeuroML2/pyr5_cell.nml
+++ b/NeuroML2/pyr5_cell.nml
@@ -1,0 +1,32 @@
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2.2.xsd" id="cell">
+    <notes>Layer 5 Pyramidal cell</notes>
+    <include href="kfast.channel.nml"/>
+    <include href="kslow.channel.nml"/>
+    <include href="nat.channel.nml"/>
+    <include href="nap.channel.nml"/>
+    <include href="IKM.channel.nml"/>
+    <cell id="pyr_cell">
+        <notes>A single compartment Layer 5 Pyramidal cell</notes>
+        <morphology id="pyr_cell_morph">
+            <segment id="0" name="soma">
+                <proximal x="0.0" y="0.0" z="0.0" diameter="23.138652263283095"/>
+                <distal x="0.0" y="0.0" z="0.0" diameter="23.138652263283095"/>
+            </segment>
+        </morphology>
+        <biophysicalProperties id="pyr_b_prop">
+            <membraneProperties>
+                <channelDensity id="kfast_channels" ionChannel="kfast" condDensity="67.2 S_per_m2" erev="-80.39 mV" ion="k"/>
+                <channelDensity id="kslow_channels" ionChannel="kslow" condDensity="475.82 S_per_m2" erev="-80.39 mV" ion="k"/>
+                <channelDensity id="nat_channels" ionChannel="nat" condDensity="236.62 S_per_m2" erev="-80.39 mV" ion="na"/>
+                <channelDensity id="nap_channels" ionChannel="nap" condDensity="1.44 S_per_m2" erev="-80.39 mV" ion="na"/>
+                <channelDensity id="km_channels" ionChannel="km" condDensity="475.82 S_per_m2" erev="-80.39 mV" ion="k"/>
+                <spikeThresh value="-20mV"/>
+                <specificCapacitance value="2.23 uF_per_cm2"/>
+                <initMembPotential value="-65mV"/>
+            </membraneProperties>
+            <intracellularProperties>
+                <resistivity value="0.1 kohm_cm"/>
+            </intracellularProperties>
+        </biophysicalProperties>
+    </cell>
+</neuroml>

--- a/NeuroML2/pyr_example_net.nml
+++ b/NeuroML2/pyr_example_net.nml
@@ -1,0 +1,13 @@
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"  xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2 https://raw.github.com/NeuroML/NeuroML2/development/Schemas/NeuroML2/NeuroML_v2.2.xsd" id="network">
+    <notes>Pyramidal cell network</notes>
+    <include href="pyr5_cell.nml"/>
+    <pulseGenerator id="pg" delay="100ms" duration="500ms" amplitude="0.4nA">
+        <notes>Simple pulse generator</notes>
+    </pulseGenerator>
+    <network id="single_pyr_cell_network">
+        <population id="pop0" component="pyr_cell" size="1">
+            <notes>A population for pyramidal cell</notes>
+        </population>
+        <explicitInput target="pop0[0]" input="pg"/>
+    </network>
+</neuroml>


### PR DESCRIPTION
- Single compartmental cell nml file named _pyr5_cell.nml_ is added. 
- _pyr_example_net.nml_ is created to simulate the results by injecting the current as in the hoc file but its failing to produce results. 

Is it necessary to run simulations on a network including a population of single cell? Can we directly run simulations on a cell instead of that.